### PR TITLE
Don't allow removing the first row in each tab

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -144,3 +144,8 @@ div.validation_text {
 div.import-details strong {
     font-size: 18px;
 }
+
+/* lets an element not be rendered but still affect the layout of the page */
+.hide-with-layout {
+    visibility: hidden;
+}

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
                             <template v-for="(item, index) in items" :key="item.id">
                                 <div :class="item.classification + (!isItemValid(item) ? ' validation_error' : '')">
                                     <div class="remove-this">
-                                        <button class="btn btn-secondary" v-on:click="removeItem(index)"><i class="bi bi-dash-lg"></i></button>        
+                                        <button :class="'btn btn-secondary' + (index == 0 ? ' hide-with-layout' : '')" v-on:click="removeItem(index)"><i class="bi bi-dash-lg"></i></button>        
                                     </div>
 
                                     <div class="form-group row">
@@ -161,7 +161,7 @@
                             <template v-for="(location, index) in locations" :key="location.id">
                                 <div :class="(location.victory ? 'victory' : '') + (!isLocationValid(location) ? ' validation_error' : '')">
                                     <div class="remove-this">
-                                        <button class="btn btn-secondary" v-on:click="removeLocation(index)"><i class="bi bi-dash-lg"></i></button>        
+                                        <button :class="'btn btn-secondary' + (index == 0 ? ' hide-with-layout' : '')" v-on:click="removeLocation(index)"><i class="bi bi-dash-lg"></i></button>        
                                     </div>
 
                                     <div class="form-group row">
@@ -238,7 +238,7 @@
                             <template v-for="(region, index) in regions" :key="region.id">
                                 <div :class="(region.starting ? 'starting' : '') + (!isRegionValid(region) ? ' validation_error' : '')">
                                     <div class="remove-this">
-                                        <button class="btn btn-secondary" v-on:click="removeRegion(index)"><i class="bi bi-dash-lg"></i></button>        
+                                        <button :class="'btn btn-secondary' + (index == 0 ? ' hide-with-layout' : '')" v-on:click="removeRegion(index)"><i class="bi bi-dash-lg"></i></button>        
                                     </div>
 
                                     <div class="form-group row">


### PR DESCRIPTION
From this bug report: https://discord.com/channels/1097532591650910289/1276964300019204158

The Builder allows you to remove every row under Items/Locations/Regions, at which point it doesn't let you add them back. This is definitely a "why would you do this" bug, but this PR prevents it regardless.