### PR TITLE
Fix bug with removing place_item* settings on locations

### DIFF
--- a/js/exporter.js
+++ b/js/exporter.js
@@ -125,16 +125,25 @@ export class Exporter {
                 location['requires'] = [];
             }
 
-            if (location['placement_type'] != 'none') {
-                switch (location['placement_type']) {
-                    case 'single_item':
-                        location['place_item'] = location['placement'].split(',').map((r) => r.trim());
-                        break;
+            switch (location['placement_type']) {
+                case 'none':
+                    if (Object.keys(location).includes('place_item')) {
+                        delete location['place_item'];
+                    }
 
-                    case 'category_item':
-                        location['place_item_category'] = location['placement'].split(',').map((r) => r.trim());
-                        break;
-                }
+                    if (Object.keys(location).includes('place_item_category')) {
+                        delete location['place_item_category'];
+                    }
+
+                    break;
+
+                case 'single_item':
+                    location['place_item'] = location['placement'].split(',').map((r) => r.trim());
+                    break;
+
+                case 'category_item':
+                    location['place_item_category'] = location['placement'].split(',').map((r) => r.trim());
+                    break;
             }
 
             for (let delete_key of ['id', 'categories', 'validation_error', 'requirements', 'placement', 'placement_type']) {


### PR DESCRIPTION
From this bug report: https://discord.com/channels/1097532591650910289/1288502089026371604

Placement Type of none was getting ignored, so place_item settings weren't getting removed after being added + exported + re-imported + removed. So this PR makes none clear out both of the place_item settings on the location.