### PR TITLE
Add roundtrip support for events.json in the builder

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
 import { createApp, computed, reactive, nextTick } from 'vue';
-import { Examples } from '../text/examples.js'; 
-import { Tooltips } from '../text/tooltips.js'; 
+import { Examples } from '../text/examples.js';
+import { Tooltips } from '../text/tooltips.js';
 import { Importer } from './importer.js';
 import { Exporter } from './exporter.js';
 import { Template } from './template.js';
@@ -31,6 +31,7 @@ const app = createApp({
             locations: [{'id': 1, 'placement_type': 'none', 'region_options': []}], // locations.json
             regions: [{'id': 1}], // regions.json
             categories: {}, // categories.json
+            events: [], // events.json
 
             totalItemsByCount: 0,
             totalLocations: 0,

--- a/js/exporter.js
+++ b/js/exporter.js
@@ -8,6 +8,7 @@ export class Exporter {
     locations = [];
     regions = [];
     categories = {};
+    events = [];
     status = '';
 
     static fromApp(vue) {
@@ -40,6 +41,7 @@ export class Exporter {
         this.locations = Exporter.prepLocations(this.vue.locations);
         this.regions = Exporter.prepRegions(this.vue.regions);
         this.categories = this.vue.categories;
+        this.events = this.vue.events;
 
         let template = self.vue.apworld_template;
         let gameFormatted = self.game.game.toLowerCase().replace(/[^A-Za-z0-9]/g, '');
@@ -47,7 +49,7 @@ export class Exporter {
         let folder_name = `manual_${gameFormatted}_${playerFormatted}`;
 
         let zip = new JSZip();
-        
+
         for (let filename in template.fileContents) {
             zip.folder(folder_name).file(filename, template.fileContents[filename]);
         }
@@ -57,7 +59,7 @@ export class Exporter {
         zip.folder(folder_name).file('data/locations.json', encodeJsonWithSpacing(this.locations));
         zip.folder(folder_name).file('data/regions.json', encodeJsonWithSpacing(this.regions));
         zip.folder(folder_name).file('data/categories.json', encodeJsonWithSpacing(this.categories));
-
+        zip.folder(folder_name).file('data/events.json', encodeJsonWithSpacing(this.events));
 
         zip.generateAsync({
             type:"blob",
@@ -93,7 +95,7 @@ export class Exporter {
             else {
                 item['category'] = [];
             }
-                        
+
             for (let delete_key of ['id', 'categories', 'classification', 'validation_error', 'progression', 'progression_skip_balancing', 'useful', 'filler', 'trap']) {
                 delete item[delete_key];
             }
@@ -118,7 +120,7 @@ export class Exporter {
             else {
                 location['category'] = [];
             }
-            
+
             location['requires'] = location['requirements'] || "";
 
             switch (location['placement_type']) {
@@ -165,7 +167,7 @@ export class Exporter {
             else {
                 region['connects_to'] = [];
             }
-            
+
             region['requires'] = region['requirements'] || "";
 
             for (let delete_key of ['id', 'validation_error', 'requirements', 'name']) {

--- a/js/importer.js
+++ b/js/importer.js
@@ -23,15 +23,16 @@ export class Importer {
         const basename = file.name.replace(/\.apworld/, '');
         const error_text = '<span style="color: red">{text}</span>';
 
-        JSZip.loadAsync(file, { createFolders: true })                                   
+        JSZip.loadAsync(file, { createFolders: true })
             .then(function(zip) {
-                
+
                 var selfref = reactive(self);
                 const file_game = zip.file(`${basename}/data/game.json`);
                 const file_items = zip.file(`${basename}/data/items.json`);
                 const file_locations = zip.file(`${basename}/data/locations.json`);
                 const file_regions = zip.file(`${basename}/data/regions.json`);
                 const file_categories = zip.file(`${basename}/data/categories.json`);
+                const file_events = zip.file(`${basename}/data/events.json`);
 
                 if (!file_game && !file_items && !file_locations && !file_regions) {
                     selfref.status = error_text.replace(
@@ -125,6 +126,16 @@ export class Importer {
                             console.log('Categories file not provided. Skipping');
                         });
                 }
+
+                if (file_events) {
+                    file_events.async('string')
+                        .then((content) => {
+                            selfref.events = self.parseJSON(content);
+                        })
+                        .catch((err) => {
+                            console.log('Events file not provided. Skipping');
+                        });
+                }
             }, function (e) {
                 var selfref = reactive(self);
                 selfref.status = `${file.name} failed because: ${e.message}`;
@@ -147,6 +158,7 @@ export class Importer {
         this.fillLocations();
         this.fillRegions();
         this.fillCategories();
+        this.fillEvents();
 
         this.status = `<strong>Loaded!</strong>`;
     }
@@ -275,6 +287,10 @@ export class Importer {
 
     fillCategories() {
         this.vue.categories = this.categories; // we can do better in the future
+    }
+
+    fillEvents() {
+        this.vue.events = this.events;
     }
 
     parseJSON(json_text) {


### PR DESCRIPTION
This does two things:

* Adds roundtrip support for an events.json if one exists
* Ensures we don't export the MvC template events.json, as that's currently making unusable apworlds (thanks to Stars Event)
