### PR TITLE
Fix undefined `Importer.events`

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -28,7 +28,7 @@ export function translateRequirementsFromArray(json_object) {
             if (translated[count]) {
                 count++; // move the OR condition into its own block
             }
-                                    
+
             if (row.hasOwnProperty('or')) {
                 translated[count] = row.or.map(
                     (r) => `|${r}|`
@@ -96,6 +96,8 @@ export async function copyJsonCollection(collection) {
 }
 
 export function encodeJsonWithSpacing(js_object) {
+    if (js_object == undefined) return 'null';
+
     let json_content = JSON.stringify(js_object, null, 2)
                         .replace(/http\:\s/g, 'http:').replace(/https\:\s/g, 'https:')
                         .replace(/\:\s*ALL/, ":ALL").replace(/\:\s*HALF/, ":HALF");

--- a/js/importer.js
+++ b/js/importer.js
@@ -9,6 +9,7 @@ export class Importer {
     locations = [];
     regions = [];
     categories = {};
+    events = [];
     status = '';
 
     static fromZip(file, app) {


### PR DESCRIPTION
Have I mentioned that I dislike writing JavaScript?



I missed an initialization in the importer, and that lead to javascript failing to serialize an `undefined`.



This PR sets the default value, and also for the sake of my own sanity, ensures that if this ever happens again, it at least serializes an undefined to null rather than hard-crashing.

