### PR TITLE
More import/export improvements

### DIFF
--- a/js/exporter.js
+++ b/js/exporter.js
@@ -105,7 +105,10 @@ export class Exporter {
             after_items.push(item);
         }
 
-        return after_items;
+        return {
+            "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.items.schema.json",
+            "data": after_items
+        };
     }
 
     static prepLocations(before_locations) {
@@ -151,11 +154,16 @@ export class Exporter {
             after_locations.push(location);
         }
 
-        return after_locations;
+        return {
+            "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.locations.schema.json",
+            "data": after_locations
+        };
     }
 
     static prepRegions(before_regions) {
-        let after_regions = {};
+        let after_regions = {
+            "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.regions.schema.json"
+        };
 
         for (let before_region of [...before_regions]) {
             let region = Object.assign({}, before_region);

--- a/js/importer.js
+++ b/js/importer.js
@@ -205,7 +205,7 @@ export class Importer {
             }
 
             if (typeof item.category === 'string')
-                item.category = item.category
+                item.categories = item.category
             else
                 item.categories = item.category?.join(', ') || '';
 
@@ -235,7 +235,7 @@ export class Importer {
             location.requirements = getRequirementsFromJSON(location.requires);
 
             if (typeof location.category === 'string')
-                location.category = location.category
+                location.categories = location.category
             else
                 location.categories = location.category?.join(', ') || '';
 

--- a/js/importer.js
+++ b/js/importer.js
@@ -173,7 +173,7 @@ export class Importer {
         else {
             this.vue.creator = this.game.player;
         }
-        
+
         this.vue.filler = this.game.filler_item_name;
         this.vue.starting_items = this.game.starting_items || [];
     }
@@ -204,7 +204,10 @@ export class Importer {
                 item.classification = 'useful';
             }
 
-            item.categories = item.category?.join(', ') || '';
+            if (typeof item.category === 'string')
+                item.category = item.category
+            else
+                item.categories = item.category?.join(', ') || '';
 
             if (!item.count) {
                 item.count = 1;
@@ -231,7 +234,10 @@ export class Importer {
         for (let location of this.locations) {
             location.requirements = getRequirementsFromJSON(location.requires);
 
-            location.categories = location.category?.join(', ') || '';
+            if (typeof location.category === 'string')
+                location.category = location.category
+            else
+                location.categories = location.category?.join(', ') || '';
 
             if (location.place_item) {
                 location.placement_type = 'single_item';


### PR DESCRIPTION
This one does a couple minor things.



It makes the builder export files with schemas, which should help anyone loading them into an IDE that supports them.



And it stops the builder from failing silently if the user forgot to put brackets around their categories.  I considered making it throw a visible error, but the intent is clear, so it was easier to just coerce the values into the expected format.

