### PR TITLE
Export Filler Name as a list

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
                         </div>
                         <div class="input-group">
                             <label for="filler">
-                                Filler Name:
+                                Filler Names:
                                 <i class="bi bi-info-circle-fill" :data-bs-title="Tooltips['SIDEBAR_FILLER_NAME']" data-bs-toggle="tooltip" data-bs-html="true"></i>
                             </label>
                             <input type="text" v-model.lazy="filler" :placeholder="Examples['SIDEBAR_FILLER_NAME']" />

--- a/js/exporter.js
+++ b/js/exporter.js
@@ -33,7 +33,7 @@ export class Exporter {
             "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.game.schema.json",
             'game': this.vue.game.replace(/[^A-Za-z0-9]/g, ''),
             'creator': this.vue.creator.replace(/[^A-Za-z0-9]/g, ''),
-            'filler_item_name': this.vue.filler,
+            'filler_item_name': this.vue.filler?.split(',').map((r) => r.trim()) || [],
             'starting_items': this.vue.starting_items,
         });
 

--- a/js/importer.js
+++ b/js/importer.js
@@ -174,7 +174,13 @@ export class Importer {
             this.vue.creator = this.game.player;
         }
 
-        this.vue.filler = this.game.filler_item_name;
+        if (typeof this.game.filler_item_name === "string") {
+            this.vue.filler = this.game.filler_item_name;
+        }
+        else {
+            this.vue.filler = this.game.filler_item_name?.join(', ') || '';
+        }
+
         this.vue.starting_items = this.game.starting_items || [];
     }
 

--- a/text/examples.js
+++ b/text/examples.js
@@ -1,7 +1,7 @@
 export const Examples = {
     SIDEBAR_GAME: "",
     SIDEBAR_CREATOR: "your name, probably",
-    SIDEBAR_FILLER_NAME: "",
+    SIDEBAR_FILLER_NAME: "Filler 1, Filler 2, etc.",
 
     ITEMS_NAME: "",
     ITEMS_CATEGORIES: "Category 1, Category 2, etc.",


### PR DESCRIPTION
Companion to https://github.com/ManualForArchipelago/Manual/pull/223, and depends on it to work properly.

This changes Filler Name to export as a list instead of a string, and splits item names with commas to create each entry in the list, in the same way that Categories and Connects To are exported.
`Filler Name` has also been renamed to `Filler Names`, and a syntax example has been added, in an attempt to convey the function to users.

I am not familiar with JavaScript so I just copied code from elsewhere in the website that did the same thing as what I wanted. I did some light testing with exporting and importing different combinations of lists and strings and could not find any issues.